### PR TITLE
[Client] socket disconnect properly and reconnect when revisit chat & dm

### DIFF
--- a/src/client/DmChat.tsx
+++ b/src/client/DmChat.tsx
@@ -1,6 +1,10 @@
 import { useNavigate, useParams } from 'react-router';
 import { UtilButton } from './components/UtilButton';
-import { chatSocket, chatSocketLeave } from './mini_chat/chat.socket';
+import {
+  chatSocket,
+  chatSocketConnect,
+  chatSocketLeave,
+} from './mini_chat/chat.socket';
 import MiniChatting from './mini_chat/MiniChatting';
 import NotificationButton from './components/NotificationButton';
 import setting from '../assets/setting.svg';
@@ -84,7 +88,19 @@ function DmPage() {
 
   useEffect(() => {
     fetchUserIdx();
+    chatSocketConnect();
+
+    return () => {
+      chatSocketLeave();
+    };
   }, []);
+
+  useEffect(() => {
+    if (!dmData) return;
+    chatSocket.emit('joinChat', {
+      room_id: dmData.idx,
+    });
+  }, [dmData]);
 
   useEffect(() => {
     if (userIdx === 0) return;

--- a/src/client/MainPage.tsx
+++ b/src/client/MainPage.tsx
@@ -103,11 +103,11 @@ function MainPage() {
     } else {
       chatSocketConnect();
 
-      // joinChat 이벤트 보내기
-      chatSocket.emit('joinChat', {
-        room_id: chatRoom.idx,
-        password: chatRoom.password,
-      });
+      //   joinChat 이벤트 보내기
+      //   chatSocket.emit('joinChat', {
+      //     room_id: chatRoom.idx,
+      //     password: chatRoom.password,
+      //   });
 
       console.log('chatRoom.idx', chatRoom.idx);
 
@@ -118,10 +118,10 @@ function MainPage() {
   const handleJoinPrivateChat = (chatRoom: IChatRoom, password: string) => {
     chatSocketConnect();
 
-    chatSocket.emit('joinChat', {
-      room_id: chatRoom.idx,
-      password: password,
-    });
+    // chatSocket.emit('joinChat', {
+    //   room_id: chatRoom.idx,
+    //   password: password,
+    // });
 
     navigate(`/chat/${chatRoom.idx}`);
   };

--- a/src/client/chat.tsx
+++ b/src/client/chat.tsx
@@ -16,7 +16,6 @@ import { FecthFriendList, Friends } from './components/FetchFriendList';
 import { ChatParticipantContextMenu } from './components/ChatParticipantItem';
 import UpdateChatStateModal from './components/UpdateChatState';
 import { useDisclosure } from '@chakra-ui/react';
-import { IChatRoom } from './components/ChatItem';
 
 interface ChatData {
   name: string;
@@ -277,12 +276,17 @@ function ChatPage() {
     //   fetchChatMembers();
     // };
 
+    chatSocket.emit('joinChat', {
+      room_id: idx,
+    });
+
     chatSocket.on('leaveChat', onClickChannelLeave);
     chatSocket.on('receiveChatParticipants', handleReceiveChatParticipants);
 
     return () => {
       chatSocket.off('leaveChat', onClickChannelLeave);
       chatSocket.off('receiveChatParticipants', handleReceiveChatParticipants);
+      chatSocketLeave();
     };
   }, [idx]);
 

--- a/src/client/components/DmNavigation.tsx
+++ b/src/client/components/DmNavigation.tsx
@@ -42,10 +42,6 @@ export const DmNavigation = () => {
 
       const dmData = makeDmData(response.data);
 
-      chatSocket.emit('joinChat', {
-        room_id: dmData.idx,
-      });
-
       if (dmData && dmData.idx) {
         navigate(`/dm/${dmData.idx}`);
       }


### PR DESCRIPTION
close #69

## 🔎 What is this PR?

- 소켓관련하여 종료가 제대로 안되고 새로고침할 시 소켓과의 연결이 종료되는 부분 해결

## 📝 Changes

- 소켓 종료 제대로 안되는 문제 해결
- 새로고침 시 소캣 재연결

## ✅ Test Checklist

- 새로고침해도 실시간으로 메시지를 주고받을 수 있는가?
- 다른 페이지로 나가면 소켓이 종료되는가?

## 📮 To Reviewers

- Chat.tsx DmChat.tsx의 useEffect만 수정했습니다.
